### PR TITLE
Fix docs build by using scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,6 @@ scipy==1.9.3
 seaborn==0.12.1
 Send2Trash==1.8.0
 six==1.16.0
-sklearn==0.0.post1
 sniffio==1.3.0
 sns==0.1
 soupsieve==2.3.2.post1


### PR DESCRIPTION
## Summary
- remove deprecated `sklearn` package from requirements

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement anyio==3.6.2)*
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: command not found)*
- `pytest -q`