### PR TITLE
Add basic MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 * Rapid prototyping of preprocessing and analysis workflows
 * Connector modules to **LLM frameworks** like:
 
-  * [LangChain](https://github.com/langchain-ai/langchain)
-  * [LlamaIndex](https://github.com/jerryjliu/llama_index)
+* [LangChain](https://github.com/langchain-ai/langchain)
+* [LlamaIndex](https://github.com/jerryjliu/llama_index)
+* Tools supporting the **Model Context Protocol (MCP)**
 
 ---
 

--- a/faster_ds/LLM/__init__.py
+++ b/faster_ds/LLM/__init__.py
@@ -1,12 +1,22 @@
 """Utility helpers for interacting with Large Language Models."""
 
-from typing import Any
+from typing import Any, Dict
+
+from .mcp import send_mcp_request
 
 
-def send_to_llm(message: Any) -> None:
+def send_to_llm(message: Any, *, server_url: str | None = None) -> None:
     """Send information to an LLM.
 
-    Currently this is a simple stub that prints the provided message. In a real
-    environment this would forward the data to a connected LLM service.
+    If ``server_url`` is provided the message is sent using the Model Context
+    Protocol (MCP) via JSON-RPC 2.0. Otherwise the message is printed to the
+    console. This function acts as a lightweight bridge between the library and
+    external MCP-compatible tools.
     """
-    print(f"[LLM]: {message}")
+    if server_url is not None:
+        send_mcp_request("deliver_message", {"message": message}, server_url)
+    else:
+        print(f"[LLM]: {message}")
+
+
+__all__ = ["send_to_llm", "send_mcp_request"]

--- a/faster_ds/LLM/mcp.py
+++ b/faster_ds/LLM/mcp.py
@@ -1,0 +1,39 @@
+"""Basic client utilities for the Model Context Protocol (MCP)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict
+
+import json
+from urllib import request
+
+
+def send_mcp_request(method: str, params: Dict[str, Any], server_url: str) -> Dict[str, Any]:
+    """Send a JSON-RPC 2.0 request via MCP to ``server_url``.
+
+    Parameters
+    ----------
+    method:
+        The MCP method/command to invoke.
+    params:
+        Parameters to send with the request.
+    server_url:
+        Endpoint of the MCP server.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed JSON response from the server.
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": method,
+        "params": params,
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(server_url, data=data, headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=10) as resp:
+        resp_data = resp.read().decode("utf-8")
+    return json.loads(resp_data)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,47 @@
+import json
+from unittest.mock import patch
+
+import faster_ds.LLM as llm
+
+
+def test_send_mcp_request():
+    payload = {"jsonrpc": "2.0", "id": "1", "result": "ok"}
+
+    class DummyResponse:
+        def __init__(self, data):
+            self._data = data
+        def read(self):
+            return json.dumps(self._data).encode("utf-8")
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    with patch("faster_ds.LLM.mcp.request.urlopen", return_value=DummyResponse(payload)) as urlopen:
+        result = llm.mcp.send_mcp_request("ping", {"foo": "bar"}, "http://test")
+
+    urlopen.assert_called_once()
+    sent_request = urlopen.call_args[0][0]
+    sent_body = json.loads(sent_request.data.decode("utf-8"))
+    assert sent_body["method"] == "ping"
+    assert sent_body["params"] == {"foo": "bar"}
+    assert result == payload
+
+
+def test_send_to_llm_via_mcp():
+    class DummyResponse:
+        def read(self):
+            return b"{}"
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    with patch("faster_ds.LLM.mcp.request.urlopen", return_value=DummyResponse()) as urlopen:
+        llm.send_to_llm("hello", server_url="http://test")
+
+    urlopen.assert_called_once()
+    sent_request = urlopen.call_args[0][0]
+    sent_body = json.loads(sent_request.data.decode("utf-8"))
+    assert sent_body["method"] == "deliver_message"
+    assert sent_body["params"]["message"] == "hello"


### PR DESCRIPTION
## Summary
- implement JSON-RPC helper `send_mcp_request`
- extend `send_to_llm` to optionally send messages via MCP
- document MCP tools in README
- test new MCP utilities

## Testing
- `pytest -q`