### PR TITLE
Add docstring copy decorator

### DIFF
--- a/faster_ds/ML/regression.py
+++ b/faster_ds/ML/regression.py
@@ -4,11 +4,14 @@ from sklearn.metrics import r2_score, mean_absolute_error, mean_squared_error
 from sklearn.model_selection import train_test_split
 
 from faster_ds.LLM import send_to_llm
+from faster_ds.doc import doc
+from .classification import Model as ClassificationModel
 
 
 class Model:
     """Simple regression model wrapper with optional LLM reporting."""
 
+    @doc(ClassificationModel.__init__)
     def __init__(
         self,
         model: sklearn.base.BaseEstimator,
@@ -37,8 +40,8 @@ class Model:
             "mse": mean_squared_error(self.y_test, self.y_pred),
         }
 
+    @doc(ClassificationModel.send_metrics_to_llm)
     def send_metrics_to_llm(self) -> None:
-        """Send computed metrics to an attached LLM service."""
         send_to_llm(
             f"Regression metrics: {self.metrics}",
             server_url=self.server_url,

--- a/faster_ds/Tools/generate_fake_data.py
+++ b/faster_ds/Tools/generate_fake_data.py
@@ -4,6 +4,8 @@ import datetime
 import numpy as np
 import matplotlib.pylab as plt
 
+from faster_ds.doc import doc
+
 
 class FakeData:
 	'''
@@ -76,18 +78,9 @@ class FakeData:
 
 		df = pd.DataFrame(data, columns=headers)
 		return df
-	@staticmethod
-	def regression_data(how_many):	
-		"""
-		Returns Pandas Dataframe with data to regression
-
-		Parameters
-		-----------
-		how_many
-			number of rows of text in dataframe
-
-
-		"""
+        @staticmethod
+        @doc(classification_data)
+        def regression_data(how_many):
 		data=[]
 		for i in range(how_many):
 			temp= Faker('en_US')

--- a/faster_ds/doc.py
+++ b/faster_ds/doc.py
@@ -1,0 +1,23 @@
+"""Utility decorator for sharing docstrings across functions."""
+
+from typing import Any, Callable
+
+
+def doc(source: Any) -> Callable[[Callable], Callable]:
+    """Return decorator that copies ``__doc__`` from *source*.
+
+    Parameters
+    ----------
+    source : Any
+        Object providing the docstring. If a string is supplied it is used
+        directly. Otherwise the ``__doc__`` attribute is read from the
+        object.
+    """
+
+    docstring = source if isinstance(source, str) else getattr(source, "__doc__", None)
+
+    def decorator(func: Callable) -> Callable:
+        func.__doc__ = docstring
+        return func
+
+    return decorator


### PR DESCRIPTION
## Summary
- create `doc` helper to copy docstrings from other objects
- reuse docstrings for regression utilities and fake data generator

## Testing
- `pytest -q`