### PR TITLE
Refactor ML models and MCP integration

### DIFF
--- a/faster_llm/LLM/__init__.py
+++ b/faster_llm/LLM/__init__.py
@@ -1,7 +1,10 @@
 """Utility helpers for interacting with Large Language Models."""
 
-from typing import Any, Dict
+from __future__ import annotations
 
+from typing import Any
+
+from .client import MCPClient
 from .mcp import send_mcp_request
 
 
@@ -20,4 +23,4 @@ def send_to_llm(message: Any, *, server_url: str | None = None) -> None:
         print(f"[LLM]: {message}")
 
 
-__all__ = ["send_to_llm", "send_mcp_request"]
+__all__ = ["send_to_llm", "send_mcp_request", "MCPClient"]

--- a/faster_llm/LLM/client.py
+++ b/faster_llm/LLM/client.py
@@ -1,0 +1,39 @@
+"""Lightweight Model Context Protocol client."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class MCPClient:
+    """Client for communicating with an MCP server via JSON-RPC 2.0."""
+
+    server_url: str
+    _request_id: int = field(init=False, default=0)
+
+    def send_request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._request_id,
+            "method": method,
+            "params": params,
+        }
+        self._request_id += 1
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self.server_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req) as response:  # pragma: no cover - network
+                return json.loads(response.read().decode("utf-8"))
+        except Exception:  # pragma: no cover - optional network
+            return {}
+
+    def deliver_message(self, message: Any) -> Dict[str, Any]:
+        return self.send_request("deliver_message", {"message": message})

--- a/faster_llm/LLM/mcp.py
+++ b/faster_llm/LLM/mcp.py
@@ -1,21 +1,13 @@
+"""Helper functions for MCP interactions."""
+
 from __future__ import annotations
 
 from typing import Any, Dict
-import json
-import urllib.request
+
+from .client import MCPClient
 
 
 def send_mcp_request(method: str, params: Dict[str, Any], server_url: str) -> Dict[str, Any]:
     """Send a JSON-RPC 2.0 request using the Model Context Protocol (MCP)."""
-    payload = {"jsonrpc": "2.0", "id": 0, "method": method, "params": params}
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        server_url,
-        data=data,
-        headers={"Content-Type": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(req) as response:  # pragma: no cover - network
-            return json.loads(response.read().decode("utf-8"))
-    except Exception:  # pragma: no cover - optional network
-        return {}
+    client = MCPClient(server_url)
+    return client.send_request(method, params)

--- a/faster_llm/ML/base.py
+++ b/faster_llm/ML/base.py
@@ -1,0 +1,40 @@
+"""Shared utilities for ML models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+from faster_llm.LLM import send_to_llm
+
+
+@dataclass
+class BaseModel:
+    """Common training and evaluation workflow for scikit-learn models."""
+
+    model: Any
+    X: pd.DataFrame
+    y: pd.Series
+    test_size: float = 0.2
+    send_to_llm_flag: bool = False
+    server_url: str | None = None
+    y_pred: pd.Series | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
+            self.X, self.y, test_size=self.test_size
+        )
+        self.model.fit(self.X_train, self.y_train)
+        self.y_pred = self.model.predict(self.X_test)
+        if self.send_to_llm_flag:
+            self.send_metrics_to_llm()
+
+    def _compute_metrics(self) -> dict:
+        raise NotImplementedError
+
+    def send_metrics_to_llm(self) -> None:
+        metrics = self._compute_metrics()
+        send_to_llm(f"Model metrics: {metrics}", server_url=self.server_url)

--- a/faster_llm/ML/classification.py
+++ b/faster_llm/ML/classification.py
@@ -1,292 +1,76 @@
-import pandas as pd
-import numpy as np
-import sklearn
-import seaborn as sns
-from sklearn.metrics import (
-    roc_curve,
-    auc,
-    accuracy_score,
-    recall_score,
-    precision_score,
-)
-from sklearn.metrics import log_loss, f1_score, confusion_matrix, classification_report
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler
+"""Utilities for training and evaluating classification models."""
+
+from __future__ import annotations
+
+from typing import Any
+
 import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+import sklearn
+from sklearn.metrics import (
+    accuracy_score,
+    auc,
+    confusion_matrix,
+    f1_score,
+    log_loss,
+    precision_score,
+    recall_score,
+    roc_curve,
+)
 
-from sklearn.metrics import roc_curve, auc, accuracy_score, recall_score, precision_score
-from faster_llm.LLM import send_to_llm
-
-
-
-
-
-class Model:
-        def __init__(
-            self,
-            model: sklearn.base.BaseEstimator,
-            X: pd.DataFrame,
-            y: pd.Series,
-            test_size: float = 0.2,
-            send_to_llm_flag: bool = False,
-            server_url: str | None = None,
-        ):
-		"""
-		:param model: sklearn model
-		:param X: features
-		:param y: target
-		:param test_size: test size
-
-		"""
-                self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(X, y, test_size=test_size)
-                self.model = model
-                self.model.fit(self.X_train, self.y_train)
-                self.y_pred = self.model.predict(self.X_test)
-                self.metrics = self._compute_metrics()
-                self.server_url = server_url
-                if send_to_llm_flag:
-                        self.send_metrics_to_llm()
+from .base import BaseModel
 
 
-	@staticmethod
-	def clf_details(model: sklearn.base.BaseEstimator)->str:
-		"""
-		:param clf: classifier
-		:return: classifier details
+class Model(BaseModel):
+    """Thin wrapper around a scikit-learn classifier."""
 
-		"""
-		return str(dir(model))
+    def _compute_metrics(self) -> dict:
+        return {
+            "accuracy": accuracy_score(self.y_test, self.y_pred),
+            "recall": recall_score(self.y_test, self.y_pred, average="binary"),
+            "precision": precision_score(self.y_test, self.y_pred, average="binary"),
+            "f1": f1_score(self.y_test, self.y_pred, average="binary"),
+        }
 
-	
-	@staticmethod
-	def plot_roc_curve(model: sklearn.base.BaseEstimator, X: pd.DataFrame, y: pd.Series)-> None:
-		"""
-		:param model: sklearn model
-		:param X: features
-		:param y: target
-		:return: plot roc curve
+    def send_metrics_to_llm(self) -> None:
+        """Send computed classification metrics to an attached LLM."""
+        from faster_llm.LLM import send_to_llm
 
-		"""
-		y_pred = model.predict_proba(X)[:, 1]
-		fpr, tpr, _ = roc_curve(y, y_pred)
-		roc_auc = auc(fpr, tpr)
-		plt.figure()
-		plt.plot(fpr, tpr, color='darkorange', lw=2, label='ROC curve (area = %0.2f)' % roc_auc)
-		plt.plot([0, 1], [0, 1], color='navy', lw=2, linestyle='--')
-		plt.xlim([0.0, 1.0])
-		plt.ylim([0.0, 1.05])
-		plt.xlabel('False Positive Rate')
-		plt.ylabel('True Positive Rate')
-		plt.title('Receiver operating characteristic example')
-		plt.legend(loc="lower right")
-		plt.show()
+        send_to_llm(
+            f"Classification metrics: {self._compute_metrics()}",
+            server_url=self.server_url,
+        )
 
+    @staticmethod
+    def plot_roc_curve(model: sklearn.base.BaseEstimator, X: pd.DataFrame, y: pd.Series) -> None:
+        y_pred = model.predict_proba(X)[:, 1]
+        fpr, tpr, _ = roc_curve(y, y_pred)
+        roc_auc = auc(fpr, tpr)
+        plt.figure()
+        plt.plot(fpr, tpr, color="darkorange", lw=2, label=f"ROC curve (area = {roc_auc:0.2f})")
+        plt.plot([0, 1], [0, 1], color="navy", lw=2, linestyle="--")
+        plt.xlim([0.0, 1.0])
+        plt.ylim([0.0, 1.05])
+        plt.xlabel("False Positive Rate")
+        plt.ylabel("True Positive Rate")
+        plt.title("Receiver operating characteristic")
+        plt.legend(loc="lower right")
+        plt.show()
 
+    @staticmethod
+    def plot_log_loss(model: sklearn.base.BaseEstimator, X_test: pd.DataFrame, y_test: pd.Series) -> None:
+        y_pred_proba = model.predict_proba(X_test)[:, 1]
+        plt.plot(log_loss(y_test, y_pred_proba))
+        plt.show()
 
-	@staticmethod
-	def plot_log_loss(model, X_test, y_test):
-		"""
-		:param model: classifier
-		:param X_test: test data
-		:param y_test: test labels
-		:return: plot of log loss
-
-		"""
-		y_pred_proba = model.predict_proba(X_test)[::, 1]
-		log_loss(y_test, y_pred_proba)
-		plt.plot(log_loss(y_test, y_pred_proba))
-		plt.show()
-
-	@staticmethod
-	def plot_acc_epoch(model: sklearn.base.BaseEstimator, X: pd.DataFrame, y: pd.Series)-> None:
-		"""
-		:param model: sklearn model
-		:param X: features
-		:param y: target
-		:return: plot accuracy per epoch
-
-		"""
-		accuracy = []
-		for i in range(1, 100):
-			model.fit(X, y)
-			y_pred = model.predict(X)
-			accuracy.append(accuracy_score(y, y_pred))
-		plt.plot(accuracy)
-		plt.show()
-
-	@staticmethod
-	def plot_confusion_matrix(model: sklearn.base.BaseEstimator, X: pd.DataFrame, y: pd.Series)-> None:
-		"""
-		:param model: sklearn model
-		:param X: features
-		:param y: target
-		:return: plot confusion matrix
-
-		"""
-		y_pred = model.predict(X)
-		cm = confusion_matrix(y, y_pred)
-		cm = pd.DataFrame(cm, index=['True Neg', 'True Pos'], columns=['Pred Neg', 'Pred Pos'])
-		cm.index.name = 'Actual'
-		cm.columns.name = 'Predicted'
-		plt.figure(figsize=(10, 7))
-		sns.heatmap(cm, cmap='Blues', annot=True, annot_kws={"size": 16}, fmt='g')
-		plt.show()
-
-
-
-
-
-
-	# @staticmethod
-	# def plot_acc_epoch():
-	# 	""" Home-made mini-batch learning
-	# 	    -> not to be used in out-of-core setting!
-	# 	"""
-	# 	N_TRAIN_SAMPLES = X_train.shape[0]
-	# 	N_EPOCHS = 25
-	# 	N_BATCH = 128
-	# 	N_CLASSES = np.unique(y_train)
-
-	# 	scores_train = []
-	# 	scores_test = []
-
-	# 		epoch = 0
-	# 		while epoch < N_EPOCHS:
-	# 		    print('epoch: ', epoch)
-	# 		    # SHUFFLING
-	# 		    random_perm = np.random.permutation(X_train.shape[0])
-	# 		    mini_batch_index = 0
-	# 		    while True:
-	# 			# MINI-BATCH
-	# 			indices = random_perm[mini_batch_index:mini_batch_index + N_BATCH]
-	# 			mlp.partial_fit(X_train[indices], y_train[indices], classes=N_CLASSES)
-	# 			mini_batch_index += N_BATCH
-
-	# 			if mini_batch_index >= N_TRAIN_SAMPLES:
-	# 			    break
-
-	# 		    # SCORE TRAIN
-	# 		    scores_train.append(mlp.score(X_train, y_train))
-
-	# 		    # SCORE TEST
-	# 		    scores_test.append(mlp.score(X_test, y_test))
-
-	# 		    epoch += 1
-
-	# 		""" Plot """
-	# 		fig, ax = plt.subplots(2, sharex=True, sharey=True)
-	# 		ax[0].plot(scores_train)
-	# 		ax[0].set_title('Train')
-	# 		ax[1].plot(scores_test)
-	# 		ax[1].set_title('Test')
-	# 		fig.suptitle("Accuracy over epochs", fontsize=14)
-	# 		plt.show()
-
-	@staticmethod
-        def confusion_matrix(model, X_test, y_test):
-                """
-                :param model: classifier
-                :param X_test: test data
-                :param y_test: test labels
-                :return: confusion matrix
-
-                """
-                y_pred = model.predict(X_test)
-                cm = confusion_matrix(y_test, y_pred)
-                return cm
-
-        def _compute_metrics(self) -> dict:
-                """Return basic classification metrics as a dictionary."""
-                return {
-                        "accuracy": accuracy_score(self.y_test, self.y_pred),
-                        "recall": recall_score(self.y_test, self.y_pred, average="binary"),
-                        "precision": precision_score(self.y_test, self.y_pred, average="binary"),
-                        "f1": f1_score(self.y_test, self.y_pred, average="binary"),
-                }
-
-        def send_metrics_to_llm(self) -> None:
-                """Send computed metrics to an attached LLM service."""
-                send_to_llm(
-                        f"Classification metrics: {self.metrics}",
-                        server_url=self.server_url,
-                )
-
-	# @staticmethod
-	# def compare_algorithms2df(sorted_by_measure='accuracy'):
-	# 	"""
-	# 	show grid with compared results - accuracy, recall, ppv, f1-measure, mcc
-	# 	:param sorted_by_measure: measure to sort by
-	# 	:return: dataframe of all algorithms sorted by measure
-	#
-	# 	"""
-	#
-	# 	MLA_columns = []
-	# 	MLA_compare = pd.DataFrame(columns = MLA_columns)
-	#
-	#
-	# 	row_index = 0
-	# 	for alg in MLA:
-	#
-	#
-	# 	    predicted = alg.fit(X_train, y_train).predict(X_test)
-	# 	    fp, tp, th = roc_curve(y_test, predicted)
-	# 	    MLA_name = alg.__class__.__name__
-	# 	    MLA_compare.loc[row_index,'MLA Name'] = MLA_name
-	# 	    MLA_compare.loc[row_index, 'MLA Train Accuracy'] = round(alg.score(X_train, Y_train), 4)
-	# 	    MLA_compare.loc[row_index, 'MLA Test Accuracy'] = round(alg.score(X1_test, Y1_test), 4)
-	# 	    MLA_compare.loc[row_index, 'MLA Precission'] = precision_score(Y1_test, predicted)
-	# 	    MLA_compare.loc[row_index, 'MLA Recall'] = recall_score(Y1_test, predicted)
-	# 	    MLA_compare.loc[row_index, 'MLA AUC'] = auc(fp, tp)
-	# 	row_index+=1
-    #
-	# 	MLA_compare.sort_values(by = ['MLA Test Accuracy'], ascending = False, inplace = True)
-	# 	return MLA_compare
-	#
-	# @staticmethod
-	# def roc_curve_MLA(MLA):
-	# 	"""
-	# 	:param MLA: list of classifiers
-	# 	:return: plot of roc curve for each classifier
-	#
-	# 	"""
-	# 	index = 1
-	# 	for alg in MLA:
-	#
-	#
-	# 	    predicted = alg.fit(X_train, Y_train).predict(X1_test)
-	# 	    fp, tp, th = roc_curve(Y1_test, predicted)
-	# 	    roc_auc_mla = auc(fp, tp)
-	# 	    MLA_name = alg.__class__.__name__
-	# 	    plt.plot(fp, tp, lw=2, alpha=0.3, label='ROC %s (AUC = %0.2f)'  % (MLA_name, roc_auc_mla))
-	#
-	# 	    index+=1
-	#
-	# 	plt.title('ROC Curve comparison')
-	# 	plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
-	# 	plt.plot([0,1],[0,1],'r--')
-	# 	plt.xlim([0,1])
-	# 	plt.ylim([0,1])
-	# 	plt.ylabel('True Positive Rate')
-	# 	plt.xlabel('False Positive Rate')
-	# 	plt.show()
-	#
-	#
-	#
-	# def metrics(self):
-	# 	"""
-	# 	:return: accuracy, recall, ppv, f1-measure, mcc
-	#
-	# 	"""
-	# 	accuracy = accuracy_score(self.y_test, self.y_pred)
-	# 	recall = recall_score(self.y_test, self.y_pred)
-	# 	precision = precision_score(self.y_test, self.y_pred)
-	# 	f1 = f1_score(self.y_test, self.y_pred)
-	# 	mcc = matthews_corrcoef(self.y_test, self.y_pred)
-	# 	return accuracy, recall, precision, f1, mcc
-	#
-
-
-
-
-	
-
+    @staticmethod
+    def plot_confusion_matrix(model: sklearn.base.BaseEstimator, X: pd.DataFrame, y: pd.Series) -> None:
+        y_pred = model.predict(X)
+        cm = confusion_matrix(y, y_pred)
+        cm_df = pd.DataFrame(cm, index=["True Neg", "True Pos"], columns=["Pred Neg", "Pred Pos"])
+        cm_df.index.name = "Actual"
+        cm_df.columns.name = "Predicted"
+        plt.figure(figsize=(10, 7))
+        sns.heatmap(cm_df, cmap="Blues", annot=True, annot_kws={"size": 16}, fmt="g")
+        plt.show()

--- a/faster_llm/ML/regression.py
+++ b/faster_llm/ML/regression.py
@@ -1,39 +1,24 @@
+"""Utilities for regression models."""
+
+from __future__ import annotations
+
 import pandas as pd
 import sklearn
-from sklearn.metrics import r2_score, mean_absolute_error, mean_squared_error
-from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-from faster_llm.LLM import send_to_llm
 from faster_llm.doc import doc
+from .base import BaseModel
 from .classification import Model as ClassificationModel
 
 
-class Model:
+class Model(BaseModel):
     """Simple regression model wrapper with optional LLM reporting."""
 
     @doc(ClassificationModel.__init__)
-    def __init__(
-        self,
-        model: sklearn.base.BaseEstimator,
-        X: pd.DataFrame,
-        y: pd.Series,
-        test_size: float = 0.2,
-        send_to_llm_flag: bool = False,
-        server_url: str | None = None,
-    ) -> None:
-        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
-            X, y, test_size=test_size
-        )
-        self.model = model
-        self.model.fit(self.X_train, self.y_train)
-        self.y_pred = self.model.predict(self.X_test)
-        self.metrics = self._compute_metrics()
-        self.server_url = server_url
-        if send_to_llm_flag:
-            self.send_metrics_to_llm()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def _compute_metrics(self) -> dict:
-        """Return basic regression metrics as a dictionary."""
         return {
             "r2": r2_score(self.y_test, self.y_pred),
             "mae": mean_absolute_error(self.y_test, self.y_pred),
@@ -42,8 +27,9 @@ class Model:
 
     @doc(ClassificationModel.send_metrics_to_llm)
     def send_metrics_to_llm(self) -> None:
+        from faster_llm.LLM import send_to_llm
+
         send_to_llm(
-            f"Regression metrics: {self.metrics}",
+            f"Regression metrics: {self._compute_metrics()}",
             server_url=self.server_url,
         )
-    


### PR DESCRIPTION
## Summary
- implement `MCPClient` class for Model Context Protocol
- refactor MCP helpers to use `MCPClient`
- provide common `BaseModel` for ML workflows
- simplify classification and regression modules
- keep existing `send_to_llm` API

## Testing
- `pytest -q`