### PR TITLE
Integrate Processing modules with MCP notifications

### DIFF
--- a/faster_llm/Processing/__init__.py
+++ b/faster_llm/Processing/__init__.py
@@ -1,3 +1,17 @@
 # -*- coding: utf-8 -*-
 """Data preprocessing and transformation utilities."""
 
+from .preprocessing import Preprocessing
+from .feature_selection import FeatureSelection
+from .handling_imbalanced import HandlingImbalanced
+from .dimension_reduction import Model as DimensionModel
+from .model_tuning import ModelTuning
+
+__all__ = [
+    "Preprocessing",
+    "FeatureSelection",
+    "HandlingImbalanced",
+    "DimensionModel",
+    "ModelTuning",
+]
+

--- a/faster_llm/Processing/dimension_reduction.py
+++ b/faster_llm/Processing/dimension_reduction.py
@@ -1,12 +1,29 @@
-"""Placeholder module for dimension reduction utilities."""
+"""Simple dimension reduction utilities with optional MCP notifications."""
 
 import pandas as pd
 import matplotlib.pylab as plt
 
-class Model:
-        """Placeholder for dimension reduction models."""
+from .utils import mcp_notify
 
-        pass
+class Model:
+    """Collection of dimension reduction helpers."""
+
+    @staticmethod
+    @mcp_notify
+    def pca(
+        df: pd.DataFrame,
+        n_components: int = 2,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
+        """Run Principal Component Analysis on ``df``."""
+        from sklearn.decomposition import PCA
+
+        pca = PCA(n_components=n_components)
+        comps = pca.fit_transform(df)
+        cols = [f"PC{i+1}" for i in range(comps.shape[1])]
+        return pd.DataFrame(comps, columns=cols, index=df.index)
 
 
 

--- a/faster_llm/Processing/feature_selection.py
+++ b/faster_llm/Processing/feature_selection.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pandas as pd
 
+from .utils import mcp_notify
+
 
 class FeatureSelection:
     """Utility class for feature selection algorithms."""
@@ -12,34 +14,94 @@ class FeatureSelection:
         """Initialize the feature selection class."""
 
     @staticmethod
+    @mcp_notify
     def cor_selector(
         X: pd.DataFrame,
         y: pd.Series,
         n_features: int,
-        method: str,
-        threshold: float,
+        method: str = "pearson",
+        threshold: float = 0.0,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> list:
-        """Select features based on correlation statistics."""
-        return NotImplementedError
+        """Select top ``n_features`` correlated with ``y``."""
+        if method not in {"pearson", "kendall", "spearman"}:
+            raise ValueError("Invalid correlation method")
+        cor = X.corrwith(y, method=method).abs()
+        if threshold > 0:
+            cor = cor[cor > threshold]
+        return list(cor.sort_values(ascending=False).head(n_features).index)
 
     @staticmethod
-    def chi2_selector(X: pd.DataFrame, y: pd.Series, n_features: int) -> list:
+    @mcp_notify
+    def chi2_selector(
+        X: pd.DataFrame,
+        y: pd.Series,
+        n_features: int,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> list:
         """Select features using the chi-squared statistic."""
-        return NotImplementedError
+        from sklearn.feature_selection import SelectKBest, chi2
+
+        selector = SelectKBest(chi2, k=n_features)
+        selector.fit(X, y)
+        cols = selector.get_support(indices=True)
+        return X.columns[cols].tolist()
 
     @staticmethod
-    def rfe_selector(X: pd.DataFrame, y: pd.Series, n_features: int) -> list:
-        """Select features using recursive feature elimination."""
-        return NotImplementedError
-
-    @staticmethod
-    def lasso_selector(X: pd.DataFrame, y: pd.Series, n_features: int) -> list:
-        """Select features using Lasso regression importance."""
-        return NotImplementedError
-
-    @staticmethod
-    def xgb_reg_feat_importances(
-        X: pd.DataFrame, y: pd.Series, n_features: int
+    @mcp_notify
+    def rfe_selector(
+        X: pd.DataFrame,
+        y: pd.Series,
+        n_features: int,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> list:
-        """Return XGBoost regression feature importances."""
-        return NotImplementedError
+        """Select features using recursive feature elimination."""
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.feature_selection import RFE
+
+        estimator = LogisticRegression(max_iter=1000)
+        selector = RFE(estimator, n_features_to_select=n_features)
+        selector = selector.fit(X, y)
+        return X.columns[selector.support_].tolist()
+
+    @staticmethod
+    @mcp_notify
+    def lasso_selector(
+        X: pd.DataFrame,
+        y: pd.Series,
+        n_features: int,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> list:
+        """Select features using Lasso regression importance."""
+        from sklearn.linear_model import Lasso
+
+        model = Lasso(alpha=0.01)
+        model.fit(X, y)
+        importance = pd.Series(abs(model.coef_), index=X.columns)
+        return importance.sort_values(ascending=False).head(n_features).index.tolist()
+
+    @staticmethod
+    @mcp_notify
+    def xgb_reg_feat_importances(
+        X: pd.DataFrame,
+        y: pd.Series,
+        n_features: int,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> list:
+        """Return feature importances from a gradient boosting regressor."""
+        from sklearn.ensemble import GradientBoostingRegressor
+
+        model = GradientBoostingRegressor()
+        model.fit(X, y)
+        imp = pd.Series(model.feature_importances_, index=X.columns)
+        return imp.sort_values(ascending=False).head(n_features).index.tolist()

--- a/faster_llm/Processing/handling_imbalanced.py
+++ b/faster_llm/Processing/handling_imbalanced.py
@@ -1,14 +1,24 @@
 """Algorithms for dealing with imbalanced datasets."""
 
 
+from .utils import mcp_notify
+
+
 class HandlingImbalanced:
     """Utility methods for balancing data."""
 
     @staticmethod
-    def smote(X, y):
+    @mcp_notify
+    def smote(
+        X,
+        y,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ):
         """Apply the SMOTE algorithm to balance classes."""
         from imblearn.over_sampling import SMOTE
 
-        smote = SMOTE(ratio="minority")
-        X_sm, y_sm = smote.fit_sample(X, y)
+        smote = SMOTE()
+        X_sm, y_sm = smote.fit_resample(X, y)
         return X_sm, y_sm

--- a/faster_llm/Processing/model_tuning.py
+++ b/faster_llm/Processing/model_tuning.py
@@ -1,12 +1,30 @@
-"""Hyperparameter tuning utilities (placeholder)."""
+"""Hyperparameter tuning utilities with optional MCP notifications."""
 
 import pandas as pd
 import numpy as np
 
+from .utils import mcp_notify
+
 
 class ModelTuning:
-  """Class stub for hyperparameter tuning utilities."""
+    """Simple wrappers around common hyperparameter search utilities."""
 
-  pass
+    @staticmethod
+    @mcp_notify
+    def grid_search(
+        model,
+        param_grid: dict,
+        X: pd.DataFrame,
+        y: pd.Series,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ):
+        """Run ``GridSearchCV`` and return the fitted search object."""
+        from sklearn.model_selection import GridSearchCV
+
+        search = GridSearchCV(model, param_grid)
+        search.fit(X, y)
+        return search
 
 

--- a/faster_llm/Processing/preprocessing.py
+++ b/faster_llm/Processing/preprocessing.py
@@ -7,66 +7,126 @@ from typing import Dict, List, Tuple
 import pandas as pd
 import numpy as np
 
-from faster_llm.LLM import send_to_llm
+from .utils import mcp_notify
 
 
 class Preprocessing:
     """Collection of common preprocessing helpers."""
 
     @staticmethod
-    def csv_as_df(dataset_name: str, path: str = "data/") -> pd.DataFrame:
+    @mcp_notify
+    def csv_as_df(
+        dataset_name: str,
+        path: str = "data/",
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Load a CSV file and return a :class:`~pandas.DataFrame`."""
         return pd.read_csv(f"{path}{dataset_name}")
 
     @staticmethod
-    def column_names(df: pd.DataFrame) -> List[str]:
+    @mcp_notify
+    def column_names(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> List[str]:
         """Return the dataframe column names."""
         return list(df.columns)
 
     @staticmethod
-    def set_X_y(df: pd.DataFrame, target: str) -> Tuple[pd.DataFrame, pd.Series]:
+    @mcp_notify
+    def set_X_y(
+        df: pd.DataFrame,
+        target: str,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> Tuple[pd.DataFrame, pd.Series]:
         """Split dataframe into ``X`` and ``y``."""
         X = df.drop(columns=target)
         y = df[target]
         return X, y
 
     @staticmethod
-    def get_numerical_columns(df: pd.DataFrame) -> List[str]:
+    @mcp_notify
+    def get_numerical_columns(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> List[str]:
         """Return a list of numerical column names."""
         return list(df.select_dtypes(include="number").columns)
 
     @staticmethod
-    def get_categorical_columns(df: pd.DataFrame) -> List[str]:
+    @mcp_notify
+    def get_categorical_columns(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> List[str]:
         """Return a list of categorical column names."""
         return list(df.select_dtypes(include="object").columns)
 
     @staticmethod
-    def is_missing(df: pd.DataFrame) -> pd.Series:
+    @mcp_notify
+    def is_missing(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.Series:
         """Return number of missing values per column."""
         return df.isnull().sum()
 
     @staticmethod
-    def count_missing(df: pd.DataFrame) -> int:
+    @mcp_notify
+    def count_missing(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> int:
         """Return total number of missing values in dataframe."""
         return int(df.isnull().sum().sum())
 
     @staticmethod
-    def normalization(df: pd.DataFrame) -> pd.DataFrame:
+    @mcp_notify
+    def normalization(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Return z-score normalized dataframe."""
         mean = df.mean()
         std = df.std()
         return (df - mean) / std
 
     @staticmethod
-    def standarization(df: pd.DataFrame) -> pd.DataFrame:
+    @mcp_notify
+    def standarization(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Scale values to [0, 1] range using max value."""
         return df / df.max()
 
     @staticmethod
+    @mcp_notify
     def na_handling(
         df: pd.DataFrame,
         strategy: str = "mean",
         specific_value: str | int | float = 0,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> pd.DataFrame:
         """Fill missing values using a chosen strategy."""
         strategies: Dict[str, pd.DataFrame] = {
@@ -83,11 +143,15 @@ class Preprocessing:
         return strategies[strategy]
 
     @staticmethod
+    @mcp_notify
     def na_column_handling(
         df: pd.DataFrame,
         col: str,
         strategy: str,
         specific_value: str | int | float = 0,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> pd.DataFrame:
         """Fill missing values for a single column."""
         if strategy == "polynomial":
@@ -109,10 +173,14 @@ class Preprocessing:
         return df
 
     @staticmethod
+    @mcp_notify
     def na_column_handling_dict(
         df: pd.DataFrame,
         col: str,
         specific_value: str | int | float = 0,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> Dict[str, pd.Series]:
         """Return a mapping of strategies to filled columns."""
         return {
@@ -126,18 +194,35 @@ class Preprocessing:
         }
 
     @staticmethod
-    def na_non_na_set(df: pd.DataFrame) -> pd.DataFrame:
+    @mcp_notify
+    def na_non_na_set(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Return rows containing at least one missing value."""
         return df[df.isnull().any(axis=1)]
 
     @staticmethod
-    def show_columns_with_nan(df: pd.DataFrame) -> List[str]:
+    @mcp_notify
+    def show_columns_with_nan(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> List[str]:
         """Return list of columns that contain NaN values."""
         return df.columns[df.isna().any()].tolist()
 
     @staticmethod
+    @mcp_notify
     def encode_object(
-        X_train: pd.DataFrame, X_test: pd.DataFrame
+        X_train: pd.DataFrame,
+        X_test: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Label encode object columns in train and test sets."""
         from sklearn import preprocessing
@@ -151,19 +236,39 @@ class Preprocessing:
         return X_train, X_test
 
     @staticmethod
-    def encode_to_num_df(df: pd.DataFrame) -> pd.DataFrame:
+    @mcp_notify
+    def encode_to_num_df(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Label encode all columns of a dataframe."""
         from sklearn.preprocessing import LabelEncoder
 
         return df.apply(LabelEncoder().fit_transform)
 
     @staticmethod
-    def decode_label_df(df: pd.DataFrame, le) -> pd.DataFrame:
+    @mcp_notify
+    def decode_label_df(
+        df: pd.DataFrame,
+        le,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Inverse transform a dataframe using a fitted encoder."""
         return df.apply(le.inverse_transform)
 
     @staticmethod
-    def encode_single_column(df: pd.DataFrame, col_name: str):
+    @mcp_notify
+    def encode_single_column(
+        df: pd.DataFrame,
+        col_name: str,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ):
         """Label encode a single column and return the encoder."""
         from sklearn.preprocessing import LabelEncoder
 
@@ -172,23 +277,49 @@ class Preprocessing:
         return df, le
 
     @staticmethod
-    def decode_single_column(df: pd.DataFrame, col_name: str, le) -> pd.DataFrame:
+    @mcp_notify
+    def decode_single_column(
+        df: pd.DataFrame,
+        col_name: str,
+        le,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Inverse transform a single encoded column."""
         df[col_name] = le.inverse_transform(df[col_name])
         return df
 
     @staticmethod
-    def one_hot_encode(df: pd.DataFrame) -> pd.DataFrame:
+    @mcp_notify
+    def one_hot_encode(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Return one-hot encoded dataframe."""
         return pd.get_dummies(df)
 
     @staticmethod
-    def decode_one_hot(df: pd.DataFrame) -> pd.DataFrame:  # pragma: no cover
+    @mcp_notify
+    def decode_one_hot(
+        df: pd.DataFrame,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:  # pragma: no cover
         """Decode a one-hot encoded DataFrame back to its original form."""
         raise NotImplementedError
 
     @staticmethod
-    def encode_to_num_series(col: pd.Series) -> Tuple[pd.Series, Dict[int, str]]:
+    @mcp_notify
+    def encode_to_num_series(
+        col: pd.Series,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> Tuple[pd.Series, Dict[int, str]]:
         """Encode a single series and return mapping."""
         from sklearn.preprocessing import LabelEncoder
 
@@ -198,7 +329,14 @@ class Preprocessing:
         return pd.Series(col_enc, index=col.index), mapping
 
     @staticmethod
-    def remove_collinear_var(df: pd.DataFrame, threshold: float = 0.9) -> pd.DataFrame:
+    @mcp_notify
+    def remove_collinear_var(
+        df: pd.DataFrame,
+        threshold: float = 0.9,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Remove highly correlated variables."""
         corr_matrix = df.corr().abs()
         upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape), k=1).astype(bool))
@@ -206,18 +344,29 @@ class Preprocessing:
         return df.drop(columns=to_drop)
 
     @staticmethod
-    def remove_to_lot_missing(df: pd.DataFrame, threshold: float = 0.7) -> pd.DataFrame:
+    @mcp_notify
+    def remove_to_lot_missing(
+        df: pd.DataFrame,
+        threshold: float = 0.7,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
+    ) -> pd.DataFrame:
         """Remove columns with a high percentage of missing values."""
         missing = df.isnull().sum() / len(df)
         cols = missing[missing > threshold].index
         return df.drop(columns=cols)
 
     @staticmethod
+    @mcp_notify
     def test_train(
         X: pd.DataFrame,
         y: pd.Series,
         ratio: float = 0.3,
         random_state: int = 100,
+        *,
+        notify: bool = False,
+        server_url: str | None = None,
     ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
         """Split data into train and test sets."""
         from sklearn.model_selection import train_test_split

--- a/faster_llm/Processing/utils.py
+++ b/faster_llm/Processing/utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from faster_llm.LLM import send_to_llm
+
+
+def mcp_notify(func: Callable) -> Callable:
+    """Decorator to optionally notify an MCP server after a function call."""
+
+    @wraps(func)
+    def wrapper(*args: Any, notify: bool = False, server_url: str | None = None, **kwargs: Any) -> Any:
+        result = func(*args, **kwargs)
+        if notify:
+            send_to_llm(f"{func.__name__} executed", server_url=server_url)
+        return result
+
+    return wrapper


### PR DESCRIPTION
## Summary
- add a decorator `mcp_notify` for optional MCP notifications
- implement PCA in dimension reduction module
- flesh out feature selection utilities with scikit-learn
- add MCP-aware SMOTE and grid search helpers
- expose Processing utilities in the package
- update preprocessing helpers to optionally notify MCP

## Testing
- `pytest -q`