### PR TITLE
Add tests for MCP client and integrations

### DIFF
--- a/tests/test_integrations_extra.py
+++ b/tests/test_integrations_extra.py
@@ -1,0 +1,45 @@
+import json
+import urllib.request
+
+from faster_llm.integrations import log_mlflow_metrics, log_to_langsmith
+
+
+def test_log_mlflow_metrics(monkeypatch):
+    logged = []
+
+    def fake_log_metric(key, value):
+        logged.append((key, value))
+
+    monkeypatch.setattr("faster_llm.integrations.mlflow.log_metric", fake_log_metric, raising=False)
+
+    log_mlflow_metrics({"a": 1, "b": 2})
+
+    assert ("a", 1.0) in logged
+    assert ("b", 2.0) in logged
+
+
+def test_log_to_langsmith(monkeypatch):
+    captured = {}
+
+    class DummyResp:
+        def read(self):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    def fake_urlopen(req):
+        captured["url"] = req.full_url
+        captured["data"] = req.data
+        return DummyResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    log_to_langsmith({"x": 1}, "http://localhost")
+
+    assert captured["url"] == "http://localhost"
+    assert json.loads(captured["data"].decode()) == {"x": 1}
+

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,52 @@
+import json
+import urllib.request
+
+from faster_llm.LLM.client import MCPClient
+
+
+def test_mcpclient_send_request(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        def read(self):
+            return b'{"jsonrpc": "2.0", "result": 42}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    def fake_urlopen(req):
+        captured["url"] = req.full_url
+        captured["data"] = req.data
+        return DummyResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = MCPClient("http://example.com")
+    result = client.send_request("foo", {"bar": 1})
+
+    assert result == {"jsonrpc": "2.0", "result": 42}
+    payload = json.loads(captured["data"].decode())
+    assert payload["method"] == "foo"
+    assert payload["params"] == {"bar": 1}
+    assert captured["url"] == "http://example.com"
+
+
+def test_mcpclient_deliver_message(monkeypatch):
+    recorded = {}
+
+    def fake_send_request(self, method, params):
+        recorded["method"] = method
+        recorded["params"] = params
+        return {"ok": True}
+
+    monkeypatch.setattr(MCPClient, "send_request", fake_send_request)
+
+    client = MCPClient("http://example.com")
+    result = client.deliver_message("hello")
+
+    assert result == {"ok": True}
+    assert recorded == {"method": "deliver_message", "params": {"message": "hello"}}
+


### PR DESCRIPTION
## Summary
- add tests for MCPClient request helpers
- add tests for integrations logging functions

## Testing
- `pytest -q`