### PR TITLE
Add Makefile and Taskfile for dev automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: test lint release
+
+# Run unit tests with pytest
+test:
+	pytest
+
+# Lint the codebase using flake8 and pydocstyle
+lint:
+	flake8 .
+	pydocstyle faster_llm
+
+# Publish a new release to PyPI using poetry
+release:
+	poetry publish --build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+tasks:
+  test:
+    desc: Run the unit test suite
+    cmds:
+      - pytest
+
+  lint:
+    desc: Lint the codebase
+    cmds:
+      - flake8 .
+      - pydocstyle faster_llm
+
+  release:
+    desc: Publish a new release via Poetry
+    cmds:
+      - poetry publish --build


### PR DESCRIPTION
## Summary
- automate testing, linting and release via Makefile
- add equivalent tasks in Taskfile.yml

## Testing
- `pytest -q`
- `flake8 .` *(fails: command not found)*
- `pydocstyle faster_llm` *(fails: command not found)*